### PR TITLE
Update README with JS conferences and knode.io mention

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,17 @@ Node.js Meatspace
 
 This project is to encourage and promote real world in-person events by/for the node.js community.
 
-The [issue tracker](https://github.com/mikeal/node-meatspace/issues) is used as a message board. If you have some ideas about in-person events or want to put something together in your area please create a new issue.
+The [issue tracker](https://github.com/mikeal/node-meatspace/issues) is used as
+a message board. If you have some ideas about in-person events or want to put
+something together in your area please create a new issues.
+
+If you're interested in sharing events in your area and how they're being run, please consider submitting a pull request to [knode.io](https://github.com/knode/meetups). These projects are partnering to provide a comprehensive view of Node.js events happening at the local user group level and larger conference scale.
 
 ## Calendar
 
-*If you know about any events that aren't listed please add them to the [README](https://github.com/mikeal/node-meatspace/blob/gh-pages/README.md) and send a pull request.*
+*If you know about any events that aren't listed please add them to the
+[README](https://github.com/mikeal/node-meatspace/blob/gh-pages/README.md) and
+send a pull request.*
 
 ### This Week
 

--- a/README.md
+++ b/README.md
@@ -3,10 +3,6 @@ Node.js Meatspace
 
 This project is to encourage and promote real world in-person events by/for the node.js community.
 
-The [issue tracker](https://github.com/mikeal/node-meatspace/issues) is used as
-a message board. If you have some ideas about in-person events or want to put
-something together in your area please create a new issues.
-
 If you're interested in sharing events in your area and how they're being run, please consider submitting a pull request to [knode.io](https://github.com/knode/meetups). These projects are partnering to provide a comprehensive view of Node.js events happening at the local user group level and larger conference scale.
 
 ## Calendar

--- a/README.md
+++ b/README.md
@@ -53,10 +53,13 @@ The [issue tracker](https://github.com/mikeal/node-meatspace/issues) is used as 
 
 ### May 2014
 * *May 5th* **Stuttgart, Germany** [Pferdle-JavaScript Meetup](http://www.meetup.com/stuttgartjs/)
+* *May 5th-6th* **New York, NY, USA** [EmpireJS](http://empirejs.org/)
 * *May 22nd-23rd* **Oslo, Norway** [Web Rebels](http://webrebels.org/)
+* *May 28th-30th* **Amelia Island, FL, USA** [JSConf](http://2014.jsconf.us/)
 
 ### June 2014
 * *Jun 2th* **Stuttgart, Germany** [Pferdle-JavaScript Meetup](http://www.meetup.com/stuttgartjs/)
+* *Jun 24th-27th* **Portland, OR, USA** [OSBridge](http://opensourcebridge.org/) 
 
 ### July 2014
 * *Jul 4th Weekend* **Marin County, CA, USA** [NodeConf 2014](http://www.nodeconf.com)

--- a/index.html
+++ b/index.html
@@ -46,9 +46,11 @@
     <a href="https://github.com/mikeal/node-meatspace"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub"></a>
   <h1 id="node-js-meatspace">Node.js Meatspace</h1>
 <p>This project is to encourage and promote real world in-person events by/for the node.js community.</p>
-<p>The <a href="https://github.com/mikeal/node-meatspace/issues">issue tracker</a> is used as a message board. If you have some ideas about in-person events or want to put something together in your area please create a new issue.</p>
+<p>If you&#39;re interested in sharing events in your area and how they&#39;re being run, please consider submitting a pull request to <a href="https://github.com/knode/meetups">knode.io</a>. These projects are partnering to provide a comprehensive view of Node.js events happening at the local user group level and larger conference scale.</p>
 <h2 id="calendar">Calendar</h2>
-<p><em>If you know about any events that aren&#39;t listed please add them to the <a href="https://github.com/mikeal/node-meatspace/blob/gh-pages/README.md">README</a> and send a pull request.</em></p>
+<p><em>If you know about any events that aren&#39;t listed please add them to the
+<a href="https://github.com/mikeal/node-meatspace/blob/gh-pages/README.md">README</a> and
+send a pull request.</em></p>
 <h3 id="this-week">This Week</h3>
 <ul>
 <li><em>Jan 3rd</em><ul>
@@ -100,11 +102,14 @@
 <h3 id="may-2014">May 2014</h3>
 <ul>
 <li><em>May 5th</em> <strong>Stuttgart, Germany</strong> <a href="http://www.meetup.com/stuttgartjs/">Pferdle-JavaScript Meetup</a></li>
+<li><em>May 5th-6th</em> <strong>New York, NY, USA</strong> <a href="http://empirejs.org/">EmpireJS</a></li>
 <li><em>May 22nd-23rd</em> <strong>Oslo, Norway</strong> <a href="http://webrebels.org/">Web Rebels</a></li>
+<li><em>May 28th-30th</em> <strong>Amelia Island, FL, USA</strong> <a href="http://2014.jsconf.us/">JSConf</a></li>
 </ul>
 <h3 id="june-2014">June 2014</h3>
 <ul>
 <li><em>Jun 2th</em> <strong>Stuttgart, Germany</strong> <a href="http://www.meetup.com/stuttgartjs/">Pferdle-JavaScript Meetup</a></li>
+<li><em>Jun 24th-27th</em> <strong>Portland, OR, USA</strong> <a href="http://opensourcebridge.org/">OSBridge</a> </li>
 </ul>
 <h3 id="july-2014">July 2014</h3>
 <ul>


### PR DESCRIPTION
This adds some more general JS conferences that have been confirmed for 2014. It also add knode.io as a contribution option for those looking to share more on their local user group.
