### PR TITLE
Add index.html to changeset after git pre-hook modifications

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -9,3 +9,7 @@ if [ $RETVAL -ne 0 ]
 then
     exit 1
 fi
+
+# If build.js succeeds, then index.html has been modified
+# Add the modified index.html to the changeset before we commit
+git add index.html


### PR DESCRIPTION
Refs #69 

Update git pre-commit hook to automatically add modified index.html to the change set.

For those of you not familiar with grunt (I wasn't 12 hours ago), you can test by:

Install grunt and install (or update) git pre-commit hook

```
> npm install -g grunt-cli
> grunt
Running "install-hooks" task

Done, without errors.
```

Make changes to README.md

```
> git add README.md
> git commit -m "My small change"
[pre-commit 9f9251d] My small change
 2 files changed, 2 insertions(+)
```

If you look at your git history you should see the updated index.html has also been committed.

cc: @gergelyke @hackygolucky 
