### PR TITLE
only build when master gets pushed to

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: node_js
 node_js:
 - '0.10'
 script: npm run-script deploy
+# whitelist master branch
+branches:
+  only:
+    - master
 env:
   global:
   - GH_REF: github.com/knode/node-meatspace.git


### PR DESCRIPTION
Currently, a push to any branch will cause a build on Travis.  By whitelisting only the master branch, we can avoid unnecessary builds.
