### PR TITLE
added Thunder Plains Conference

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,6 @@ send a pull request.*
 * *Jul 7th* **Stuttgart, Germany** [Pferdle-JavaScript Meetup](http://www.meetup.com/stuttgartjs/)
 * *Jul 17th* **Saint Louis, MO, USA** [STLJS: Special Presentation](http://www.meetup.com/STL-JS-meetup/events/154371372/)
 * *Jul 31st-Aug 1st* **Portland, OR, USA** [CascadiaJS 2014](http://www.cascadiajs.com/)
+
+### October 2014
+* *October 9th* **Oklahoma City, OK, USA** [Thunder Plains Developer Conference](http://thunderplainsconf.com/)


### PR DESCRIPTION
Updated README.md to include Thunder Plains Conference. See [https://github.com/knode/node-meatspace/pull/111](https://github.com/knode/node-meatspace/pull/111).
